### PR TITLE
Harden GitHub Actions security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             os: ubuntu-24.04
             rebar3: 3.25
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -43,7 +43,7 @@ jobs:
       - name: Code coverage
         run: rebar3 as test do cover,covertool generate
       - name: Upload coverage report
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: _build/test/covertool/rebar3_hex.covertool.xml
           name: ${{matrix.otp}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
             rebar3: 3.25
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
             os: ubuntu-24.04
             rebar3: 3.25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
@@ -43,7 +43,7 @@ jobs:
       - name: Code coverage
         run: rebar3 as test do cover,covertool generate
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: _build/test/covertool/rebar3_hex.covertool.xml
           name: ${{matrix.otp}}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "31 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,3 +37,16 @@ jobs:
         uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:
           category: "/language:${{matrix.language}}"
+
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0


### PR DESCRIPTION
## Summary

  This PR contains multiple commits improving GitHub Actions security:

  - **Disable credential persistence** - Add `persist-credentials: false` to `actions/checkout`
  - **Restrict workflow permissions** - Add explicit `contents: read` permissions
  - **Pin GitHub Actions to commit SHAs** - Prevent supply chain attacks via tag hijacking
  - **Update GitHub Actions** - Upgrade to latest versions:
    - `actions/checkout`: v4.3.1 → v6.0.2
    - `codecov/codecov-action`: v4.6.0 → v6.0.0
  - **Add security scanning** - CodeQL workflow for static analysis and zizmor for CI/CD security auditing
  - **Add Dependabot** - Keep GitHub Actions up to date with grouped weekly PRs

  Similar changes have already been applied to:
  - Elixir: https://github.com/elixir-lang/elixir/pull/15114
  - Hex: https://github.com/hexpm/hex/pull/1110
  - Rebar3: https://github.com/erlang/rebar3/pull/3001

  ## Required Repository Settings

  After merging, enable the following repository settings in "Rules" / "Rulesets":

  Add "Require code scanning results" with the following tools:
  - `CodeQL`
  - `zizmor`

  Set "Security Alerts" and "Alert" to "All":

  <img width="774" height="311" alt="Screenshot 2026-02-25 at 12 29 11" src="https://github.com/user-attachments/assets/4598d486-29b3-425f-8523-e547ec92c183" />

  That way PR merges are blocked until all issues have been identified.

  ## References

  - https://docs.zizmor.sh/audits/
  - https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-actions/